### PR TITLE
Should fix Issue #51

### DIFF
--- a/src/main/java/jotato/quantumflux/storehouse/TileEntityStorehouse.java
+++ b/src/main/java/jotato/quantumflux/storehouse/TileEntityStorehouse.java
@@ -109,7 +109,11 @@ public class TileEntityStorehouse extends TileEntity implements IInventory {
 
 		for (int i = 0; i < nbttaglist.tagCount(); ++i) {
 			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			int j = nbttagcompound1.getInteger("Slot");
+			int j;
+			if (nbttagcompound1.hasKey("Slot")) // Compatibility check
+				j = nbttagcompound1.getByte("Slot") & 255;
+			else
+				j = nbttagcompound1.getInteger("SlotID");
 
 			if (j >= 0 && j < this.inventory.length) {
 				this.inventory[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
@@ -125,7 +129,7 @@ public class TileEntityStorehouse extends TileEntity implements IInventory {
 		for (int i = 0; i < this.inventory.length; ++i) {
 			if (this.inventory[i] != null) {
 				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setInteger("Slot", i);
+				nbttagcompound1.setInteger("SlotID", i);
 				this.inventory[i].writeToNBT(nbttagcompound1);
 				nbttaglist.appendTag(nbttagcompound1);
 			}

--- a/src/main/java/jotato/quantumflux/storehouse/TileEntityStorehouse.java
+++ b/src/main/java/jotato/quantumflux/storehouse/TileEntityStorehouse.java
@@ -109,7 +109,7 @@ public class TileEntityStorehouse extends TileEntity implements IInventory {
 
 		for (int i = 0; i < nbttaglist.tagCount(); ++i) {
 			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			int j = nbttagcompound1.getByte("Slot") & 255;
+			int j = nbttagcompound1.getInteger("Slot");
 
 			if (j >= 0 && j < this.inventory.length) {
 				this.inventory[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
@@ -125,7 +125,7 @@ public class TileEntityStorehouse extends TileEntity implements IInventory {
 		for (int i = 0; i < this.inventory.length; ++i) {
 			if (this.inventory[i] != null) {
 				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setByte("Slot", (byte) i);
+				nbttagcompound1.setInteger("Slot", i);
 				this.inventory[i].writeToNBT(nbttagcompound1);
 				nbttaglist.appendTag(nbttagcompound1);
 			}


### PR DESCRIPTION
Hi Jotato
I think I found the source of all evil regarding the storehouse leak (#51).
By storing the slot ID (which can be an integer from 0 to 999 I believe) as a byte value (which can only store values from 0 to 256) you start overwriting the slots after 256 items.

This PR should fix this by not converting the integer value and storing it directly.
However this change is not going to work too well with storehouses in already existing worlds and will result in possibly loosing more items when updating.