### PR TITLE
Should fix #54

### DIFF
--- a/src/main/java/jotato/quantumflux/machine/cluster/TileEntityCreativeCluster.java
+++ b/src/main/java/jotato/quantumflux/machine/cluster/TileEntityCreativeCluster.java
@@ -30,6 +30,9 @@ public class TileEntityCreativeCluster extends TileEntity implements IEnergyProv
 
 	@Override
 	public void updateEntity() {
+		if (worldObj.isRemote)
+			return;
+
 		for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 			int targetX = xCoord + dir.offsetX;
 			int targetY = yCoord + dir.offsetY;

--- a/src/main/java/jotato/quantumflux/machine/cluster/TileEntityQuibitCluster.java
+++ b/src/main/java/jotato/quantumflux/machine/cluster/TileEntityQuibitCluster.java
@@ -122,6 +122,9 @@ public class TileEntityQuibitCluster extends TileEntity implements IEnergyHandle
 
 	@Override
 	public void updateEntity() {
+		if (worldObj.isRemote)
+			return;
+
 		for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 			int targetX = xCoord + dir.offsetX;
 			int targetY = yCoord + dir.offsetY;

--- a/src/main/java/jotato/quantumflux/machine/fabricator/TileEntityItemFabricator.java
+++ b/src/main/java/jotato/quantumflux/machine/fabricator/TileEntityItemFabricator.java
@@ -161,7 +161,9 @@ public class TileEntityItemFabricator extends TileEntity implements IEnergyRecei
 	@Override
 	public void updateEntity() {
 
-		
+		if (worldObj.isRemote)
+			return;
+
 		if (canDoWork()) {
 			int toConsume = getEnergyConsumedPerTick();
 			int energyUsed = energyStorage.extractEnergy(toConsume, false);


### PR DESCRIPTION
I added some worldObj.isRemote checks for the Quibit Clusters and the Item Fabricator.
This should prevent the visual glitch, which displayed an energy loss when a GUI was open.