### PR TITLE
Fix range of the imaginary time block & exciter collision box

### DIFF
--- a/src/main/java/jotato/quantumflux/machine/exciter/BlockRFExciter.java
+++ b/src/main/java/jotato/quantumflux/machine/exciter/BlockRFExciter.java
@@ -1,16 +1,20 @@
 package jotato.quantumflux.machine.exciter;
 
+import java.util.List;
+
 import jotato.quantumflux.ConfigMan;
 import jotato.quantumflux.blocks.BlockBase;
 import jotato.quantumflux.items.ModItems;
 import jotato.quantumflux.proxy.ClientProxy;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -23,13 +27,20 @@ public class BlockRFExciter extends BlockBase {
 
 	public BlockRFExciter() {
 		super(Material.circuits, "rfExciter", .25f, "pickaxe", 0, ItemBlockRFExciter.class);
-		this.setBlockBounds(.15f, 0f, .15f, .85f, .12f, .85f);
 	}
 
 	@Override
 	protected String getTexture(String name) {
 		// TODO Auto-generated method stub
 		return super.getTexture("exciter/" + name);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List list, Entity entity)
+	{
+		this.setBlockBoundsBasedOnState(world, x, y, z);
+		super.addCollisionBoxesToList(world, x, y, z, mask, list, entity);
 	}
 
 	@Override

--- a/src/main/java/jotato/quantumflux/machine/imaginarytime/TileEntityImaginaryTime.java
+++ b/src/main/java/jotato/quantumflux/machine/imaginarytime/TileEntityImaginaryTime.java
@@ -79,9 +79,9 @@ public class TileEntityImaginaryTime extends TileEntity implements IEnergyReceiv
 			int passes = ConfigMan.imaginaryTime_tickIncrease;
 			Block block;
 			
-			for(int x2=x-range;x2<x+range; x2++)
+			for(int x2=x-range; x2<=x+range; x2++)
 			{
-				for(int z2=z-range;z2<z+range; z2++)
+				for(int z2=z-range; z2<=z+range; z2++)
 				{
 					for(int y2=y-2;y2<y+2; y2++)
 					{


### PR DESCRIPTION
The range of the imaginary time block was 1 block short towards the positive X and Z axis.
http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2379902-quantumflux-wireless-rf-1-3-1?comment=88