### PR TITLE
Change loading from NBT to fix #128.

### DIFF
--- a/src/main/java/jotato/quantumflux/machines/entangler/TileRFEntangler.java
+++ b/src/main/java/jotato/quantumflux/machines/entangler/TileRFEntangler.java
@@ -64,18 +64,17 @@ public class TileRFEntangler extends TileEntity implements IEnergyReceiver, IRed
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound tag)
 	{
-		tag=super.writeToNBT(tag);
+		super.writeToNBT(tag);
 
-		if(owner==null){
-			//todo: I don't know how this happens, but it does. Probably on a server crash
-			return tag;
-		}
-		
 		NBTTagCompound energyTag = new NBTTagCompound();
 		this.storage.writeToNBT(energyTag);
 		tag.setTag("Energy", energyTag);
-		tag.setString("owner", owner.toString());
-		
+
+		if(owner != null)
+		{
+			tag.setString("owner", owner.toString());
+		}
+
 		return tag;
 	}
 
@@ -83,16 +82,21 @@ public class TileRFEntangler extends TileEntity implements IEnergyReceiver, IRed
 	public void readFromNBT(NBTTagCompound tag)
 	{
 		super.readFromNBT(tag);
-		try{
+
 		NBTTagCompound energyTag = tag.getCompoundTag("Energy");
 		this.storage.readFromNBT(energyTag);
-		this.owner = UUID.fromString(tag.getString("owner"));
-		
+
+		try
+		{
+			this.owner = UUID.fromString(tag.getString("owner"));
+		}
+		catch (IllegalArgumentException ex)
+		{
+			if (!worldObj.isRemote)
+				Logger.error("HEY YOU! An RF Entangler at %d, %d, %d has no owner, please replace it.", getPos().getX(), getPos().getY(), getPos().getZ());
+		}
+
 		registerWithField();
-		}
-		catch(Exception ex){
-			Logger.error("HEY YOU! An RF Entangler at %d, %d, %d has corrupt data. The owner needs to replace it", getPos().getX(), getPos().getY(), getPos().getZ());
-		}
 	}
 
 	@Override

--- a/src/main/java/jotato/quantumflux/machines/exciter/TileRFExciter.java
+++ b/src/main/java/jotato/quantumflux/machines/exciter/TileRFExciter.java
@@ -85,7 +85,7 @@ public class TileRFExciter extends TileEntity implements IEnergyProvider, ITicka
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound tag)
 	{
-		tag=super.writeToNBT(tag);
+		super.writeToNBT(tag);
 		
 		tag.setInteger("upgradeCount", upgradeCount);
 		
@@ -102,15 +102,17 @@ public class TileRFExciter extends TileEntity implements IEnergyProvider, ITicka
 	public void readFromNBT(NBTTagCompound tag)
 	{
 		super.readFromNBT(tag);
+
+		this.upgradeCount = tag.getInteger("upgradeCount");
+
 		try
 		{
 			this.owner = UUID.fromString(tag.getString("owner"));
-			this.upgradeCount = tag.getInteger("upgradeCount");
 		}
-		catch(Exception ex)
+		catch (IllegalArgumentException ex)
 		{
-			Logger.error("HEY YOU! An RF Exciter has corrupt data at %s The owner will need to replace it.", getPos());
-			
+			if (!worldObj.isRemote)
+				Logger.error("HEY YOU! An RF Exciter at %d, %d, %d has no owner, please replace it.", getPos().getX(), getPos().getY(), getPos().getZ());
 		}
 	}
 


### PR DESCRIPTION
Summary: 
Only display the error message mentioned in #128 when reading the NBT from the server fails. (There will be no NBT information in the client.)

Fixes #128